### PR TITLE
Redirect to the new website

### DIFF
--- a/aboutus.html
+++ b/aboutus.html
@@ -1,6 +1,7 @@
 <html>
 	<head>
 		<meta charset="UTF-8">
+		<meta http-equiv="refresh" content="0; url=https://newtonmeetingcamden.org">
 		<title></title>
 		<link rel="stylesheet" href="assets/SASS/style.css">
 		<link href='https://fonts.googleapis.com/css?family=Libre+Baskerville' rel='stylesheet' type='text/css'>

--- a/gardenproject.html
+++ b/gardenproject.html
@@ -1,6 +1,7 @@
 <html>
 	<head>
 		<meta charset="UTF-8">
+		<meta http-equiv="refresh" content="0; url=https://newtonmeetingcamden.org">
 		<title></title>
 		<link rel="stylesheet" href="assets/SASS/style.css">
 		<link href='https://fonts.googleapis.com/css?family=Libre+Baskerville' rel='stylesheet' type='text/css'>
@@ -48,8 +49,8 @@
 			</div>
 <!-- MAIN CONTENT -->
 			<div class="pagewrapper">
-				<div class="textwrapper gardenpage">	
-					<div>	
+				<div class="textwrapper gardenpage">
+					<div>
 						<h1>The Garden Project</h1>
 							<img src="assets/images/sunflower.jpg" alt="" class="left">
 							<p>
@@ -92,12 +93,12 @@
 								Many Garden Project participants welcome the opportunity to work the soil and to provide produce for the program and for others through community service.
 							</p>
 								<hr>
-							<p class="quote"> 
+							<p class="quote">
 								The Garden Project is a place I can come on Saturdats and forget about everything that week and be treated like a human being, not judged - that means so much to us
 							</p>
-							
+
 								<q>I'm taking bags of vegetables with me when I go and taking them to my boys and say 'See what I grew for you! Eat all your vegetables!'</q>
-							
+
 					</div>
 						<hr>
 					<div>
@@ -146,14 +147,14 @@
 						<a href="index.html#directions">Directions</a><br>
 						<a href="#">Donate</a><br>
 						<a href="http://www.pym.org/">Philadelphia Yearly Meeting</a>
-					</div>				
+					</div>
 				</div>
 			</footer>
 
 <!-- ~~~~~~~~~~  END FOOTER~~~~~~~~~~~~~~~~~ -->
 		</div>
 
-	
+
 	<script src="https://code.jquery.com/jquery-2.1.4.js"></script>
 	<script type="text/javascript" script src="assets/scripts/javascript.js"></script>
 	</body>

--- a/history.html
+++ b/history.html
@@ -1,6 +1,7 @@
 <html>
 	<head>
 		<meta charset="UTF-8">
+		<meta http-equiv="refresh" content="0; url=https://newtonmeetingcamden.org">
 		<title></title>
 		<link rel="stylesheet" href="assets/SASS/style.css">
 		<link href='https://fonts.googleapis.com/css?family=Libre+Baskerville' rel='stylesheet' type='text/css'>

--- a/historyofquakerism.html
+++ b/historyofquakerism.html
@@ -1,6 +1,7 @@
 <html>
 	<head>
 		<meta charset="UTF-8">
+		<meta http-equiv="refresh" content="0; url=https://newtonmeetingcamden.org">
 		<title></title>
 		<link rel="stylesheet" href="assets/SASS/style.css">
 		<link href='https://fonts.googleapis.com/css?family=Libre+Baskerville' rel='stylesheet' type='text/css'>
@@ -57,7 +58,7 @@
 							The close of the seventeenth century brought an end to persecutions.  A period of “quietism” provided an exemplary way of life, of loving communities characterized by simplicity and serenity. A fine example of this way of life was John Woolman (1720-1772) of Mount Holly, New Jersey.  He traveled by foot and horseback up and down the colonies, persuading Quaker slave owners to free their slaves. Woolman’s Journal is a classic not only of Quakerism, but of American literature.
 						</p>
 						<p>
-							Friends were, with few exceptions, neutral in the French and Indian and Revolutionary Wars; this cost them a great deal of membership and influence. Quakers were a part of the westward movement of European settlement across the continent. 
+							Friends were, with few exceptions, neutral in the French and Indian and Revolutionary Wars; this cost them a great deal of membership and influence. Quakers were a part of the westward movement of European settlement across the continent.
 						</p>
 						<p>
 							Friends were active against slavery, founding antislavery societies, editing abolitionist papers, and playing an important role in supporting the escaped slave leaders of the “underground railroad” to help more slaves escape across the free but perilous northern states to Canada. Quaker women, first active in the anti-slavery movement, became the dominant leadership of nineteenth-century movements for women’s rights. Especially notable were Lucretia Mott and the Grimke sisters.
@@ -81,7 +82,7 @@
 					</div>
 
 
-					
+
 				</div>
 
 <!-- ~~~~~~~~~~~~~~  FOOTER  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
@@ -98,7 +99,7 @@
 						<a href="index.html#directions">Directions</a><br>
 						<a href="#">Donate</a><br>
 						<a href="http://www.pym.org/">Philadelphia Yearly Meeting</a>
-					</div>				
+					</div>
 				</div>
 			</footer>
 

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <html>
 	<head>
 		<meta charset="UTF-8">
+		<meta http-equiv="refresh" content="0; url=https://newtonmeetingcamden.org">
 		<meta name="description" content="Newton Friends Meeting Camden is a Quaker community in New Jersey, dating from 1679 that meets on Sundays for food, fellowship, growing, harvesting food, green practices, nonviolence, silent worship.">
 		<meta name="keywords" content="newton,quaker,camden,meeting,friends, nonviolence,silent worship,green practices,growing,fellowship,harvesting,food,new jersey,">
 		<meta name="author" content="Newton Monthly Meeting">

--- a/links.html
+++ b/links.html
@@ -1,6 +1,7 @@
 <html>
 	<head>
 		<meta charset="UTF-8">
+		<meta http-equiv="refresh" content="0; url=https://newtonmeetingcamden.org">
 		<title></title>
 		<link rel="stylesheet" href="assets/SASS/style.css">
 		<link href='https://fonts.googleapis.com/css?family=Libre+Baskerville' rel='stylesheet' type='text/css'>
@@ -54,7 +55,7 @@
 				</div>
 				<div class="textwrapper">
 					<h2>Quaker Links & Resources</h2>
-						<ul class="quakerlinks"> 
+						<ul class="quakerlinks">
 							<li>
 								<a href="http://www.pym.org/">Philadelphia Yearly Meeting</a> Newton Monthly Meeting Religious Society of Friends is one of 103 monthly meetings (and 13 quarterly meetings) in PYM
 							</li>
@@ -143,11 +144,11 @@
 							<li>
 								<a href="http://friendscouncil.org/">Friends Council on Education</a> - Locate Friends Schools throughout the world.
 							</li>
-							<li> 
+							<li>
 								<a href="http://www.friendseducationfund.org/">Friends Education Fund</a> - Information about tuition assistance for Friends children.
 							</li>
 						</ul>
-				</div>	
+				</div>
             </div>
 <!-- ~~~~~~~~~~~~~~  FOOTER  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 
@@ -163,7 +164,7 @@
 						<a href="index.html#directions">Directions</a><br>
 						<a href="#">Donate</a><br>
 						<a href="http://www.pym.org/">Philadelphia Yearly Meeting</a>
-					</div>				
+					</div>
 				</div>
 			</footer>
 

--- a/myfirst.html
+++ b/myfirst.html
@@ -1,6 +1,7 @@
 <html>
 	<head>
 		<meta charset="UTF-8">
+		<meta http-equiv="refresh" content="0; url=https://newtonmeetingcamden.org">
 		<title></title>
 		<link rel="stylesheet" href="assets/SASS/style.css">
 		<link href='https://fonts.googleapis.com/css?family=Libre+Baskerville' rel='stylesheet' type='text/css'>
@@ -61,21 +62,21 @@
 						I was informed about Newton Meeting for Worship through Michael Romano.  He was a coordinator of the Food Not Bombs program. The program has permission from Newton Meeting to use their premises to cook delicious vegetarian meals for Camden’s indigent population and serve them, where they are, on the streets.  Michael Romano and I had been through similar hard knocks in our own lives and shared similar philosophies about religion and outreach for Camden.  He said he was Quaker told me about Newton Friends in Camden.  I knew I needed to go to visit as soon as possible.
 					</p>
 					<p>
-						I was feeling disappointed with the top-down methodology at the church I was attending.  It wasn’t a right fit for me anymore. I didn’t desire to worship through this methodology anymore. God’s words for me, was different from what I was repeating in church.  
+						I was feeling disappointed with the top-down methodology at the church I was attending.  It wasn’t a right fit for me anymore. I didn’t desire to worship through this methodology anymore. God’s words for me, was different from what I was repeating in church.
 					</p>
 					<p>
-						When I went to Newton Meeting for the first time the garden was starting to bloom. Sunflowers stretched out to the sky, ripening tomatoes hung on vines; there was an actual fig tree… I was soaking in all this beauty.  At Newton, the beauty I saw around me matched the feelings I experienced working with children and adults in Camden. A man in jeans and checked shirt,  God depicted by Michelangelo, met me as I walked around the property. He was obviously the gardener, later I learned he was the property clerk. He showed me the children’s garden, and the Saturday program garden, all cared for by this property clerk, and various Camden residents. Here was God in action. 
+						When I went to Newton Meeting for the first time the garden was starting to bloom. Sunflowers stretched out to the sky, ripening tomatoes hung on vines; there was an actual fig tree… I was soaking in all this beauty.  At Newton, the beauty I saw around me matched the feelings I experienced working with children and adults in Camden. A man in jeans and checked shirt,  God depicted by Michelangelo, met me as I walked around the property. He was obviously the gardener, later I learned he was the property clerk. He showed me the children’s garden, and the Saturday program garden, all cared for by this property clerk, and various Camden residents. Here was God in action.
 					</p>
 					<p>
 						At 10:30 I went in for the meeting.  It was a small building with pictures of (here you will have to fill in the blanks) over a fireplace. Wooden pews were placed in a circle.  The antiquity of this building was palpable and filled me with an intense feeling of stepping back in time. William Penn could have sat in one of these pews.
 					</p>
 					<p>
-						There were approximately 6 people at this meeting, some older, some younger. We sat in silence. I was used to meditation and had been to a retreat years ago at Pendle Hill, so I thought I knew what to expect from a Quaker worship meeting.  What I did not expect was a testimony that moved me to tears, not from a church authority sanctioned to speak at me, but a sharing of God working in an equal’s life.  This testimony was from an older man, white hair pulled back into a ponytail, dress clothes and a head band, like I had worn in my "Hippy" days.  He shared about a family vacation to a farm in Michigan where he grew up.  He shared that the tree that he watched his grandson play in, was the same tree he had played in when he was a child. He spoke of how the love of nature, fostered by the relationship to this landscape, will continue from generation to generation. 
+						There were approximately 6 people at this meeting, some older, some younger. We sat in silence. I was used to meditation and had been to a retreat years ago at Pendle Hill, so I thought I knew what to expect from a Quaker worship meeting.  What I did not expect was a testimony that moved me to tears, not from a church authority sanctioned to speak at me, but a sharing of God working in an equal’s life.  This testimony was from an older man, white hair pulled back into a ponytail, dress clothes and a head band, like I had worn in my "Hippy" days.  He shared about a family vacation to a farm in Michigan where he grew up.  He shared that the tree that he watched his grandson play in, was the same tree he had played in when he was a child. He spoke of how the love of nature, fostered by the relationship to this landscape, will continue from generation to generation.
 					</p>
 					<p>
 						When there was silence again, from within me came the words "La’dor vador," which is a Hebrew for, "from generation to generation." The song of that same title with all its meaning resounded in me and I was with that spontaneous prayer. It wasn’t even a Holiday. In English, "From generation to generation… your miracles give us reason to live. From generation to generation… Passing down what’s been passed down to me makes my life complete."  Within, I was lead to my own worship surrounded by others going where their stillness took them.
 					</p>
-					<p>  
+					<p>
 						When the meeting for worship came to a close, I was welcomed, heard and seen by everyone.   The gathering was small enough not to be overwhelming.  I felt like was visiting a family.
 					</p>
 					<p>
@@ -100,7 +101,7 @@
 						<a href="index.html#directions">Directions</a><br>
 						<a href="#">Donate</a><br>
 						<a href="http://www.pym.org/">Philadelphia Yearly Meeting</a>
-					</div>				
+					</div>
 				</div>
 			</footer>
 

--- a/whoare.html
+++ b/whoare.html
@@ -1,6 +1,7 @@
 <html>
 	<head>
 		<meta charset="UTF-8">
+		<meta http-equiv="refresh" content="0; url=https://newtonmeetingcamden.org">
 		<title></title>
 		<link rel="stylesheet" href="assets/SASS/style.css">
 		<link href='https://fonts.googleapis.com/css?family=Libre+Baskerville' rel='stylesheet' type='text/css'>
@@ -55,7 +56,7 @@
 							Newton Friends Meeting is a Quaker community in Camden, New Jersey, dating from 1679. The Meeting has a long tradition of service to the people of Camden. We are a small meeting of about a dozen people. We gather for worship only twice a month, on the first and third Sundays, but our service programs take place every weekend. Our property comprises most of a city block and supports two lush gardens and play space.
 						</p>
 						<hr>
-					<h3 id="whoarethequakers">Who Are the Quakers?</h3> 
+					<h3 id="whoarethequakers">Who Are the Quakers?</h3>
 						<p>
 							Quakers are members of the Religious Society of Friends, a faith that emerged as a new Christian denomination in England during a period of religious turmoil in the mid-1600's and is practiced today in a variety of forms around the world.  "Quaker"and "Friend" mean the same thing.
 						</p>
@@ -77,7 +78,7 @@
 							The close of the seventeenth century brought an end to persecutions.  A period of “quietism” provided an exemplary way of life, of loving communities characterized by simplicity and serenity. A fine example of this way of life was John Woolman (1720-1772) of Mount Holly, New Jersey.  He traveled by foot and horseback up and down the colonies, persuading Quaker slave owners to free their slaves. Woolman’s Journal is a classic not only of Quakerism, but of American literature.
 						</p>
 						<p>
-							Friends were, with few exceptions, neutral in the French and Indian and Revolutionary Wars; this cost them a great deal of membership and influence. Quakers were a part of the westward movement of European settlement across the continent. 
+							Friends were, with few exceptions, neutral in the French and Indian and Revolutionary Wars; this cost them a great deal of membership and influence. Quakers were a part of the westward movement of European settlement across the continent.
 						</p>
 						<p>
 							Friends were active against slavery, founding antislavery societies, editing abolitionist papers, and playing an important role in supporting the escaped slave leaders of the “underground railroad” to help more slaves escape across the free but perilous northern states to Canada. Quaker women, first active in the anti-slavery movement, became the dominant leadership of nineteenth-century movements for women’s rights. Especially notable were Lucretia Mott and the Grimke sisters.
@@ -117,7 +118,7 @@
 						<a href="#">Directions</a><br>
 						<a href="#">Donate</a><br>
 						<a href="#">Philadelphia Yearly Meeting</a>
-					</div>				
+					</div>
 				</div>
 			</footer>
 


### PR DESCRIPTION
Eventually, this page should be taken down. But folks might have
it bookmarked, and other websites link to it right now, [such as this one](http://www.pym.org/meetings/meeting/newton-monthly-meeting/). Therefore, taking
it down could cause confusion if the link is broken.

Instead, this adds a redirect so that visitors to this page will
be taken to the new site.

In a few months (say, 3-6 months), it will probably be safe to
completely take down this page.

---

You can verify that this approach works by going to this URL:

http://moracaitlin.github.io/meetingSite/

This same approach was implemented there in [this PR](https://github.com/moracaitlin/meetingSite/pull/1).

---

Lastly, forgive the whitespace changes. My text editor removes extraneous whitespace.